### PR TITLE
update common service to v0.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/@EssexManagement/clinical-trial-matching-service": {
-      "version": "0.2.3",
-      "resolved": "https://npm.pkg.github.com/download/@EssexManagement/clinical-trial-matching-service/0.2.3/7a14c65ebfde692814093cd49e30b628e353aabb",
-      "integrity": "sha512-UPch02QLM7Q5y2z/RtD5S/x+ex1OlJd/VpvxIkhD1Qjzu038BDJc/61KnAuzLIW4VJ8OkuiuIT5Y6qEeGp+f6A==",
+      "version": "0.2.5",
+      "resolved": "https://npm.pkg.github.com/download/@EssexManagement/clinical-trial-matching-service/0.2.5/7f10764a1bb4817f2775909b73ed5812e581cb6d",
+      "integrity": "sha512-5qkhARtu5pV+5u+IT63bTNlQBgU2wKvmJiKvYmrCy6cTKgV3tWxwWRKklmjau723Y4aYPheuUEdMwD1WOgpDhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",


### PR DESCRIPTION
- includes updates to generic types needed by chore/add-lint-to-ci