### PR TITLE
Chore/add lint to ci

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,4 +29,5 @@ jobs:
       - run: npm ci
       - run: npm run-script lint
       - run: npm run-script coverage
+      - run: npm run-script lint
       # - uses: codecov/codecov-action@v4

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,5 +29,4 @@ jobs:
       - run: npm ci
       - run: npm run-script lint
       - run: npm run-script coverage
-      - run: npm run-script lint
       # - uses: codecov/codecov-action@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/@EssexManagement/clinical-trial-matching-service": {
-      "version": "0.2.3",
-      "resolved": "https://npm.pkg.github.com/download/@EssexManagement/clinical-trial-matching-service/0.2.3/7a14c65ebfde692814093cd49e30b628e353aabb",
-      "integrity": "sha512-UPch02QLM7Q5y2z/RtD5S/x+ex1OlJd/VpvxIkhD1Qjzu038BDJc/61KnAuzLIW4VJ8OkuiuIT5Y6qEeGp+f6A==",
+      "version": "0.2.5",
+      "resolved": "https://npm.pkg.github.com/download/@EssexManagement/clinical-trial-matching-service/0.2.5/7f10764a1bb4817f2775909b73ed5812e581cb6d",
+      "integrity": "sha512-5qkhARtu5pV+5u+IT63bTNlQBgU2wKvmJiKvYmrCy6cTKgV3tWxwWRKklmjau723Y4aYPheuUEdMwD1WOgpDhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",

--- a/spec/server.spec.ts
+++ b/spec/server.spec.ts
@@ -8,7 +8,6 @@ describe("startServer()", () => {
     // Don't actually want to start the server listening, so spy on the
     // prototype to prevent that from happening
     spyOn(ClinicalTrialMatchingService.prototype, "listen").and.callFake(
-      // @ts-ignore: don't care about the implementation
       () => {
       // Note: null return works here because the result of service is never
       // actually used in the "real" function

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -80,7 +80,7 @@ export async function getMatches(
 
   if (devCacheClient instanceof DevCacheClient) {
     const key = options.url + options.data;
-    const cached = (await devCacheClient.get(key)) as CbApiResponse;
+    const cached = await devCacheClient.get<CbApiResponse>(key);
     if (cached) {
       return { data: cached, status: 200 };
     }


### PR DESCRIPTION
This pull request contains minor improvements to type safety and code clarity in both the test suite and the API client.

- **Type safety improvement:**
  * Updated the call to `devCacheClient.get` in `src/apiClient.ts` to use a generic type parameter for better type inference and safety.

- **Test code clarity:**
  * Removed an unnecessary `@ts-ignore` comment in the `startServer()` test, as the implementation detail is no longer relevant.